### PR TITLE
Fix complex header rendering

### DIFF
--- a/vue3-migration/src/components/DataTable.vue
+++ b/vue3-migration/src/components/DataTable.vue
@@ -203,8 +203,7 @@ const {
 
 // Advanced features composables
 const groupConfig = computed(() => props.grouping)
-const nestedConfig = computed(() => props.nestedGrid) 
-const complexHeadersEnabled = computed(() => props.complexHeaders)
+const nestedConfig = computed(() => props.nestedGrid)
 
 // Create a computed data source for grouping that considers nested processing
 const groupingDataSource = computed(() => {
@@ -228,10 +227,13 @@ const {
   toggleNestedRow 
 } = useNestedGrid(data, nestedConfig)
 
-const { 
-  headerStructure, 
-  leafColumns 
+const {
+  headerStructure,
+  leafColumns,
+  hasComplexHeaders
 } = useComplexHeaders(columns)
+
+const complexHeadersEnabled = computed(() => hasComplexHeaders.value)
 
 // Determine final data to display based on enabled features
 const finalData = computed(() => {

--- a/vue3-migration/src/components/DataTable.vue
+++ b/vue3-migration/src/components/DataTable.vue
@@ -47,10 +47,12 @@
 
     <!-- Main Table -->
     <main class="mh-datatable__content">
-      <Table 
+      <Table
         ref="tableRef"
         :columns="finalColumns"
-        :data="finalData" 
+        :header-columns="columns"
+        :complex-headers="complexHeadersEnabled"
+        :data="finalData"
         :total="total"
         :query="query"
         :loading="loading"

--- a/vue3-migration/src/components/Table/ComplexTableHeader.vue
+++ b/vue3-migration/src/components/Table/ComplexTableHeader.vue
@@ -14,10 +14,11 @@
       </th>
       
       <!-- Regular header cells -->
-      <th v-for="(header, headerIndex) in level" 
+      <th v-for="(header, headerIndex) in level"
           :key="`${levelIndex}-${headerIndex}-${header.field}`"
+          :data-index="isLeafHeader(header) ? getColumnIndex(header) : null"
           :class="['mh-table-cell', 'mh-table-header-cell', header.class]"
-          :style="[header.style, { minWidth: '80px' }]"
+          :style="[header.style, isLeafHeader(header) ? { width: getHeaderWidth(header) } : {}, { minWidth: '80px' }]"
           :colspan="header.colspan"
           :rowspan="header.rowspan"
           @click="handleHeaderClick(header, levelIndex, headerIndex)">
@@ -260,6 +261,25 @@ function isFilterApplied(header: ComplexHeader): boolean {
 function getColumnIndex(header: ComplexHeader): number {
   const column = getColumnForHeader(header)
   return column?.index || 0
+}
+
+/**
+ * Get width for header cell
+ */
+function getHeaderWidth(header: ComplexHeader): string | undefined {
+  const column = getColumnForHeader(header)
+  if (column?.colStyle?.width) {
+    return column.colStyle.width
+  }
+  if (header.children) {
+    const childWidths = header.children
+      .map(child => parseFloat(getHeaderWidth(child) || '0'))
+      .reduce((a, b) => a + b, 0)
+    if (childWidths > 0) {
+      return `${childWidths}px`
+    }
+  }
+  return undefined
 }
 
 /**

--- a/vue3-migration/src/components/Table/Table.vue
+++ b/vue3-migration/src/components/Table/Table.vue
@@ -36,31 +36,62 @@
         <!-- Left fixed header -->
         <div class="mh-table-fixed-left" v-if="leftFixedColumns.length > 0" :style="{ width: `${fixedLeftTableWidth}px` }">
           <TableFrame left-fixed :tableColumns="leftFixedColumns" :shouldRenderSelection="props.selectable">
-            <TableHeader :tableColumns="leftFixedColumns" :query="query" leftFixed :shouldRenderSelection="props.selectable" :bodyData="data" @handle-event="handleTableHeaderEvent" @header-resize="handleHeaderResize" @sort="handleSort" @menu-action="handleMenuAction">
+            <component
+              :is="complexHeadersEnabled ? ComplexTableHeader : TableHeader"
+              :columns="headerColumns"
+              :table-columns="leftFixedColumns"
+              :query="query"
+              leftFixed
+              :shouldRenderSelection="props.selectable"
+              :bodyData="data"
+              @handle-event="handleTableHeaderEvent"
+              @header-resize="handleHeaderResize"
+              @sort="handleSort"
+              @menu-action="handleMenuAction"
+            >
               <template v-for="(_, slot) in $slots" #[slot]="scope">
                 <slot :name="slot" v-bind="scope" />
               </template>
-            </TableHeader>
+            </component>
           </TableFrame>
         </div>
         <!-- Main header -->
         <div ref="mainTableHeader" class="mh-table-main" :style="{ 'margin-left': `${fixedLeftTableWidth}px`, 'margin-right': `${fixedRightTableWidth}px` }">
-                      <TableFrame :tableColumns="normalColumns" :shouldRenderSelection="leftFixedColumns.length === 0 ? props.selectable : false">
-            <TableHeader :tableColumns="normalColumns" :query="query" :shouldRenderSelection="leftFixedColumns.length === 0 ? props.selectable : false" @header-resize="handleHeaderResize" @sort="handleSort" @menu-action="handleMenuAction">
+          <TableFrame :tableColumns="normalColumns" :shouldRenderSelection="leftFixedColumns.length === 0 ? props.selectable : false">
+            <component
+              :is="complexHeadersEnabled ? ComplexTableHeader : TableHeader"
+              :columns="headerColumns"
+              :table-columns="normalColumns"
+              :query="query"
+              :shouldRenderSelection="leftFixedColumns.length === 0 ? props.selectable : false"
+              @header-resize="handleHeaderResize"
+              @sort="handleSort"
+              @menu-action="handleMenuAction"
+            >
               <template v-for="(_, slot) in $slots" #[slot]="scope">
                 <slot :name="slot" v-bind="scope" />
               </template>
-            </TableHeader>
+            </component>
           </TableFrame>
         </div>
         <!-- Right fixed header -->
         <div class="mh-table-fixed-right" v-if="rightFixedColumns.length > 0" :style="{ width: `${fixedRightTableWidth}px` }">
           <TableFrame right-fixed :tableColumns="rightFixedColumns" :shouldRenderSelection="false">
-            <TableHeader :tableColumns="rightFixedColumns" :query="query" rightFixed :shouldRenderSelection="false" @header-resize="handleHeaderResize" @sort="handleSort" @menu-action="handleMenuAction">
+            <component
+              :is="complexHeadersEnabled ? ComplexTableHeader : TableHeader"
+              :columns="headerColumns"
+              :table-columns="rightFixedColumns"
+              :query="query"
+              rightFixed
+              :shouldRenderSelection="false"
+              @header-resize="handleHeaderResize"
+              @sort="handleSort"
+              @menu-action="handleMenuAction"
+            >
               <template v-for="(_, slot) in $slots" #[slot]="scope">
                 <slot :name="slot" v-bind="scope" />
               </template>
-            </TableHeader>
+            </component>
           </TableFrame>
         </div>
       </div>
@@ -292,6 +323,7 @@ import { useVirtualScrolling } from '@/composables/useVirtualScrolling'
 import type { TableProps, TableColumn, TableHeightConfig, TableQuery, NestedGridConfig } from '@/types'
 import TableFrame from './TableFrame.vue'
 import TableHeader from './TableHeader.vue'
+import ComplexTableHeader from './ComplexTableHeader.vue'
 import TableBody from './TableBody.vue'
 import GroupedTableBody from './GroupedTableBody.vue'
 import TableFooter from './TableFooter.vue'
@@ -299,7 +331,7 @@ import ColumnMenu from '../ColumnMenu/ColumnMenu.vue'
 import ContextMenu from '../ContextMenu/ContextMenu.vue'
 
 // Props
-const props = defineProps<TableProps & { loading?: boolean; summary?: Record<string, any>; selectable?: boolean; nestedGrid?: NestedGridConfig; groupConfig?: any }>()
+const props = defineProps<TableProps & { loading?: boolean; summary?: Record<string, any>; selectable?: boolean; nestedGrid?: NestedGridConfig; groupConfig?: any; headerColumns?: TableColumn[]; complexHeaders?: boolean }>()
 
 // Emits
 const emit = defineEmits<{
@@ -315,15 +347,18 @@ const emit = defineEmits<{
 }>()
 
 // Composables
-const { 
-  columns, 
-  data, 
-  query, 
+const {
+  columns,
+  data,
+  query,
   visibleColumns,
   leftFixedColumns,
   rightFixedColumns,
-  normalColumns 
+  normalColumns
 } = useTableState(props)
+
+const headerColumns = computed(() => props.headerColumns || props.columns)
+const complexHeadersEnabled = computed(() => props.complexHeaders === true)
 
 // Integrate modular column actions
 const {


### PR DESCRIPTION
## Summary
- add hierarchical data to `useComplexHeaders`
- filter complex headers per table section
- render `ComplexTableHeader` in `Table.vue`
- pass original columns for headers from `DataTable`
